### PR TITLE
Don't include store dir in IPFS JSON keys

### DIFF
--- a/src/libstore/ipfs-binary-cache-store.cc
+++ b/src/libstore/ipfs-binary-cache-store.cc
@@ -378,33 +378,27 @@ private:
                 json["references"].emplace(ref.to_string(), narMap[(std::string) ref.to_string()]);
         }
 
-        if (narInfo->ca != "")
-            json["ca"] = narInfo->ca;
+        json["ca"] = narInfo->ca;
 
         if (narInfo->deriver)
             json["deriver"] = printStorePath(*narInfo->deriver);
 
-        if (narInfo->registrationTime)
-            json["registrationTime"] = narInfo->registrationTime;
+        json["registrationTime"] = narInfo->registrationTime;
+        json["ultimate"] = narInfo->ultimate;
 
-        if (narInfo->ultimate)
-            json["ultimate"] = narInfo->ultimate;
-
-        if (!narInfo->sigs.empty()) {
-            json["sigs"] = nlohmann::json::array();
-            for (auto & sig : narInfo->sigs)
-                json["sigs"].push_back(sig);
-        }
+        json["sigs"] = nlohmann::json::array();
+        for (auto & sig : narInfo->sigs)
+            json["sigs"].push_back(sig);
 
         if (!narInfo->url.empty()) {
             json["ipfsCid"] = nlohmann::json::object();
             json["ipfsCid"]["/"] = std::string(narInfo->url, 7);
         }
+
         if (narInfo->fileHash)
             json["downloadHash"] = narInfo->fileHash.to_string(Base32, true);
-        if (narInfo->fileSize)
-            json["downloadSize"] = narInfo->fileSize;
 
+        json["downloadSize"] = narInfo->fileSize;
         json["compression"] = narInfo->compression;
         json["system"] = narInfo->system;
 


### PR DESCRIPTION
This makes the root node look like this:

```
{
  "StoreDir": "/nix/store",
  "nar": {
    "269z7gqi6mdbvmfdsv7nk18sgm6zd9xf-nghttp2-1.40.0-lib": {
      "/": "bafyreiewryjja4sxr6niros5pverb2fr5zy34nn7zydxogkyl522uaknfy"
    },
    "27aszd2yq42n25prv67spcwr7x7g74np-openssl-1.1.1g": {
      "/": "bafyreiavkdzyzcth6noqn6chk5hi2fk5r4r5vmin5hhaqivtbugmyon5xq"
    },
    "5ykk483wrqfqncivk4sj79aa2rz28xnn-libc++abi-7.1.0": {
      "/": "bafyreiarzhiqawhiilgxnwghpghqe6zr2enmr7dh2gop2xfp6jcb6re42a"
    },
    "921hbkb2y4pjlh51zqz07x0awx4apksg-libssh2-1.9.0": {
      "/": "bafyreiaomcw42to2yip4z3dvlbjwsjrpuytrqztwmbooqmjsaof7gzk5su"
    },
    "b7qbiwggfcj7hp3zllzfmqvxnqcdx9ji-swift-corefoundation": {
      "/": "bafyreibc4ucbw6x2jmczcryoqlgvd5jimqs4cvpl7rokwg6pxuknihdx5i"
    },
    "bgl70l7xlphp8msy1nwpigp6xjzfcra9-libkrb5-1.18": {
      "/": "bafyreiand3p2xqjb2rdi4qhhoqjda3jrkegofhauqaxxi3nvkkwhem7lnq"
    },
    "ilgf30winx4zw3acm5pk79cvhzkjch0f-bash-4.4-p23": {
      "/": "bafyreifx27q373s5shcilfjffgcdvvnuomw2d6rdqe4am5kjm4jjoohgpq"
    },
    "k900fsjq9kjrj5wcn85zn341qi464409-libc++-7.1.0": {
      "/": "bafyreibe3r53yfbb6hqgah575r2f5f5pw5w4id7264whg2inqhxmtllxx4"
    },
    "m2qfcxpymjs366ba8pd52mp0lifx31nw-ICU-osx-10.10.5": {
      "/": "bafyreigvg635vimxvmhbbca2e3l36h4kjfmy5s4l6xqv35qoizsixyvyfi"
    },
    "mi9z1dmjp95n90lfy3rqifqzxphvnyzh-zlib-1.2.11": {
      "/": "bafyreidcxav53lz3sp7xkpf6sn5dnm5ct3x4uyu63y2x4qdpch4xpgnwt4"
    },
    "nb3ag6cn5s856vykaiaz43qpc0ajkira-Libsystem-osx-10.12.6": {
      "/": "bafyreigzkesmvnyask6oktu6xveyi636lwrmduu4fo5wrxtt342nck473q"
    },
    "s5g8gskga7wfxbqgvvdxn02m6givzj6l-hello-2.10": {
      "/": "bafyreidwijutycp3s5iiihsmn5dmhkewwjmomdbc7zrxeeutkuq2fjbkaa"
    },
    "v9pb2nfz6y2jb44fk0zl6fk1cdrgfxs2-libxml2-2.9.10": {
      "/": "bafyreianhkcnzxbehus4gn2xveiz5u6dw6usp7txfcfsxnrzuas5igerny"
    },
    "w2mrrbg49975lfpdkz5xk5l0xdkw8fm9-curl-7.70.0": {
      "/": "bafyreidtv3i5zk4ygeapxlbrtt6zihpi4iem5wmir5pcl2vs4srsry75cq"
    }
  }
}
```

and individual narinfos look like:

```
{
  "compression": "xz",
  "deriver": "/nix/store/v47jzfaq24q4w0mmppmc17xq66jhy7fn-nghttp2-1.40.0.drv",
  "downloadHash": "sha256:1fv764qvrvs13a4kmg0i67czid0ljp4y373sga72liyxqgjgl4zm",
  "downloadSize": 56724,
  "hasSelfReference": true,
  "narHash": "sha256:0vw65cf63krzrzrzh4n6mnrpnfygwyqi50qhilpx1927nvmka8gp",
  "narSize": 162096,
  "references": {
    "nb3ag6cn5s856vykaiaz43qpc0ajkira-Libsystem-osx-10.12.6": {
      "/": "bafyreigzkesmvnyask6oktu6xveyi636lwrmduu4fo5wrxtt342nck473q"
    }
  },
  "registrationTime": 1591207555,
  "sigs": [
    "cache.nixos.org-1:NveQw9mPo0HQrnIYN9yuhAkggtPOQ8LJXWYWOrF1FIwMoUOSU+OG6W2o9YlaokThZrGgh1x2mU1qcV138h/XDw=="
  ],
  "system": "",
  "url": {
    "/": "QmXhVhEJwkKcXDD4VL9BebN7PyKwevKmcRa2j2kYtzmVpw"
  }
}
```