### PR TITLE
Sync stores at the end of commands, not within

### DIFF
--- a/release-common.nix
+++ b/release-common.nix
@@ -55,6 +55,7 @@ rec {
       git
       mercurial
       gmock
+      jq
     ]
     ++ lib.optionals stdenv.isLinux [libseccomp utillinuxMinimal]
     ++ lib.optional (stdenv.isLinux || stdenv.isDarwin) libsodium

--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -76,7 +76,6 @@ DownloadFileResult downloadFile(
         };
         auto source = StringSource { *sink.s };
         store->addToStore(info, source, NoRepair, NoCheckSigs);
-        store->sync();
         storePath = std::move(info.path);
     }
 
@@ -147,7 +146,6 @@ Tree downloadTarball(
         auto topDir = tmpDir + "/" + members.begin()->name;
         lastModified = lstat(topDir).st_mtime;
         unpackedStorePath = store->addToStore(name, topDir, FileIngestionMethod::Recursive, htSHA256, defaultPathFilter, NoRepair);
-        store->sync();
     }
 
     Attrs infoAttrs({

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -681,8 +681,6 @@ void copyPaths(ref<Store> srcStore, ref<Store> dstStore, const StorePathSet & st
             nrDone++;
             showProgress();
         });
-
-    dstStore->sync();
 }
 
 

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -527,6 +527,8 @@ static void _main(int argc, char * * argv)
             if (auto store2 = store.dynamic_pointer_cast<LocalFSStore>())
                 store2->addPermRoot(store->parseStorePath(symlink.second), absPath(symlink.first), true);
 
+        store->sync();
+
         logger->stop();
 
         for (auto & path : outPaths)

--- a/src/nix-channel/nix-channel.cc
+++ b/src/nix-channel/nix-channel.cc
@@ -120,6 +120,8 @@ static void update(const StringSet & channelNames)
 
         // Regardless of where it came from, add the expression representing this channel to accumulated expression
         exprs.push_back("f: f { name = \"" + cname + "\"; channelName = \"" + name + "\"; src = builtins.storePath \"" + filename + "\"; " + extraAttrs + " }");
+
+        store->sync();
     }
 
     // Unpack the channel tarballs into the Nix store and install them

--- a/src/nix-collect-garbage/nix-collect-garbage.cc
+++ b/src/nix-collect-garbage/nix-collect-garbage.cc
@@ -88,6 +88,7 @@ static int _main(int argc, char * * argv)
             GCResults results;
             PrintFreed freed(true, results);
             store->collectGarbage(options, results);
+            store->sync();
         }
 
         return 0;

--- a/src/nix-copy-closure/nix-copy-closure.cc
+++ b/src/nix-copy-closure/nix-copy-closure.cc
@@ -61,6 +61,9 @@ static int _main(int argc, char ** argv)
 
         copyPaths(from, to, closure, NoRepair, NoCheckSigs, useSubstitutes);
 
+        from->sync();
+        to->sync();
+
         return 0;
     }
 }

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -1455,6 +1455,8 @@ static int _main(int argc, char * * argv)
 
         globals.state->printStats();
 
+        store->sync();
+
         logger->stop();
 
         return 0;

--- a/src/nix-instantiate/nix-instantiate.cc
+++ b/src/nix-instantiate/nix-instantiate.cc
@@ -169,6 +169,7 @@ static int _main(int argc, char * * argv)
                 if (p == "") throw Error("unable to find '%1%'", i);
                 std::cout << p << std::endl;
             }
+            store->sync();
             return 0;
         }
 
@@ -188,6 +189,8 @@ static int _main(int argc, char * * argv)
         }
 
         state->printStats();
+
+        store->sync();
 
         return 0;
     }

--- a/src/nix-prefetch-url/nix-prefetch-url.cc
+++ b/src/nix-prefetch-url/nix-prefetch-url.cc
@@ -227,6 +227,8 @@ static int _main(int argc, char * * argv)
         if (printPath)
             std::cout << store->printStorePath(*storePath) << std::endl;
 
+        store->sync();
+
         return 0;
     }
 }

--- a/src/nix-store/nix-store.cc
+++ b/src/nix-store/nix-store.cc
@@ -167,8 +167,6 @@ static void opAdd(Strings opFlags, Strings opArgs)
 
     for (auto & i : opArgs)
         cout << fmt("%s\n", store->printStorePath(store->addToStore(std::string(baseNameOf(i)), i)));
-
-    store->sync();
 }
 
 
@@ -190,8 +188,6 @@ static void opAddFixed(Strings opFlags, Strings opArgs)
 
     for (auto & i : opArgs)
         cout << fmt("%s\n", store->printStorePath(store->addToStore(std::string(baseNameOf(i)), i, recursive, hashAlgo)));
-
-    store->sync();
 }
 
 
@@ -964,7 +960,6 @@ static void opServe(Strings opFlags, Strings opArgs)
                 SizedSource sizedSource(in, info.narSize);
 
                 store->addToStore(info, sizedSource, NoRepair, NoCheckSigs);
-                store->sync();
 
                 // consume all the data that has been sent before continuing.
                 sizedSource.drainAll();
@@ -1110,6 +1105,9 @@ static int _main(int argc, char * * argv)
             store = openStore();
 
         op(opFlags, opArgs);
+
+        if (store)
+            store->sync();
 
         logger->stop();
 

--- a/src/nix/add-to-store.cc
+++ b/src/nix/add-to-store.cc
@@ -56,7 +56,6 @@ struct CmdAddToStore : MixDryRun, StoreCommand
         if (!dryRun) {
             auto source = StringSource { *sink.s };
             store->addToStore(info, source);
-            store->sync();
         }
 
         logger->stdout("%s", store->printStorePath(info.path));

--- a/src/nix/command.cc
+++ b/src/nix/command.cc
@@ -28,7 +28,9 @@ ref<Store> StoreCommand::createStore()
 
 void StoreCommand::run()
 {
-    run(getStore());
+    auto store = getStore();
+    run(store);
+    store->sync();
 }
 
 StorePathsCommand::StorePathsCommand(bool recursive)

--- a/src/nix/copy.cc
+++ b/src/nix/copy.cc
@@ -96,6 +96,8 @@ struct CmdCopy : StorePathsCommand
 
         copyPaths(srcStore, dstStore, StorePathSet(storePaths.begin(), storePaths.end()),
             NoRepair, checkSigs, substitute);
+
+        dstStore->sync();
     }
 };
 

--- a/src/nix/make-content-addressable.cc
+++ b/src/nix/make-content-addressable.cc
@@ -103,8 +103,6 @@ struct CmdMakeContentAddressable : StorePathsCommand, MixJSON
 
             remappings.insert_or_assign(std::move(path), std::move(info.path));
         }
-
-        store->sync();
     }
 };
 


### PR DESCRIPTION
This should make it easier to ensure we always sync once, and don't wastefully sync intermediate.