### PR TITLE
Don’t put “refs” in ipfs ca

### DIFF
--- a/tests/ipfs.sh
+++ b/tests/ipfs.sh
@@ -227,7 +227,7 @@ nix copy $rewrite --to ipfs://
 
 nix-store --delete $rewrite
 
-path5=$(nix --experimental-features 'nix-command ca-references' ensure-ca full:dependencies-top:refs,0:$ca --substituters ipfs:// --option substitute true)
+path5=$(nix --experimental-features 'nix-command ca-references' ensure-ca full:dependencies-top:$ca --substituters ipfs:// --option substitute true)
 
 [ $(nix-store -q --references $path5 | wc -l) = $numRefs ]
 [ $(readlink -f $path5/self) = $path5 ]


### PR DESCRIPTION
We don’t need refs here since the hash already has it for us.