### PR TITLE
Read offset buffer when rewriting modulo sink

### DIFF
--- a/src/libstore/ipfs-binary-cache-store.cc
+++ b/src/libstore/ipfs-binary-cache-store.cc
@@ -569,8 +569,10 @@ std::unique_ptr<Source> IPFSBinaryCacheStore::getGitObject(std::string path, std
             size_t i = result.size() - 1;
             for (; i > 0; i--) {
                 char c = result.data()[i];
-                if (!(c >= '0' && c <= '9') && c != '|')
+                if (!(c >= '0' && c <= '9') && c != '|') {
+                    i += offset.size();
                     break;
+                }
                 if (c == '|') {
                     int pos;
                     try {


### PR DESCRIPTION
When data ends in a number, it’s not necessarily an actual offset
added in the ModuloSink. So, we need to avoid erasing that part from
the buffer if we find something that doesn’t look like |%d.